### PR TITLE
fix: PID file location in init.d script

### DIFF
--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -130,6 +130,7 @@ RUN sed -i 's,listen       80;,listen       8080;,' /etc/nginx/conf.d/default.co
     && sed -i '/user  nginx;/d' /etc/nginx/nginx.conf \
     && sed -i 's,\(/var\)\{0\,1\}/run/nginx.pid,/tmp/nginx.pid,' /etc/nginx/nginx.conf \
     && sed -i "/^http {/a \    proxy_temp_path /tmp/proxy_temp;\n    client_body_temp_path /tmp/client_temp;\n    fastcgi_temp_path /tmp/fastcgi_temp;\n    uwsgi_temp_path /tmp/uwsgi_temp;\n    scgi_temp_path /tmp/scgi_temp;\n" /etc/nginx/nginx.conf \
+    && sed -i 's,PIDFILE=${PIDFILE:-/run/nginx.pid},PIDFILE=${PIDFILE:-/tmp/nginx.pid},' /etc/init.d/nginx \
 # nginx user must own the cache and etc directory to write cache and tweak the nginx config
     && chown -R $UID:0 /var/cache/nginx \
     && chmod -R g+w /var/cache/nginx \


### PR DESCRIPTION
### Proposed changes

Will fix #321

Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) here in this description (not in the title of the PR).

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md)
- [X] I have run the [`update.sh`](/update.sh) script and ensured all entrypoint/Dockerfile template changes have been applied to the relevant image entrypoint scripts & Dockerfiles
- [x] I have tested that the NGINX Docker unprivileged image builds and runs correctly on all supported architectures on an unprivileged environment (check out the [`README`](/README.md) for more details)
- [x] I have updated any relevant documentation ([`README.md`](/README.md))
