### PR TITLE
fix: Pass GPG key ids as separate arguments when exporting.

### DIFF
--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -33,7 +33,7 @@ RUN set -x \
         done; \
         test -z "$found" && echo >&2 "error: failed to fetch GPG key $NGINX_GPGKEY" && exit 1; \
     done; \
-    gpg1 --export "$NGINX_GPGKEYS" > "$NGINX_GPGKEY_PATH" ; \
+    gpg1 --export $NGINX_GPGKEYS > "$NGINX_GPGKEY_PATH" ; \
     rm -rf "$GNUPGHOME"; \
     apt-get remove --purge --auto-remove -y gnupg1 && rm -rf /var/lib/apt/lists/* \
     && dpkgArch="$(dpkg --print-architecture)" \

--- a/mainline/debian/Dockerfile
+++ b/mainline/debian/Dockerfile
@@ -38,7 +38,7 @@ RUN set -x \
         done; \
         test -z "$found" && echo >&2 "error: failed to fetch GPG key $NGINX_GPGKEY" && exit 1; \
     done; \
-    gpg1 --export "$NGINX_GPGKEYS" > "$NGINX_GPGKEY_PATH" ; \
+    gpg1 --export $NGINX_GPGKEYS > "$NGINX_GPGKEY_PATH" ; \
     rm -rf "$GNUPGHOME"; \
     apt-get remove --purge --auto-remove -y gnupg1 && rm -rf /var/lib/apt/lists/* \
     && dpkgArch="$(dpkg --print-architecture)" \

--- a/stable/debian/Dockerfile
+++ b/stable/debian/Dockerfile
@@ -38,7 +38,7 @@ RUN set -x \
         done; \
         test -z "$found" && echo >&2 "error: failed to fetch GPG key $NGINX_GPGKEY" && exit 1; \
     done; \
-    gpg1 --export "$NGINX_GPGKEYS" > "$NGINX_GPGKEY_PATH" ; \
+    gpg1 --export $NGINX_GPGKEYS > "$NGINX_GPGKEY_PATH" ; \
     rm -rf "$GNUPGHOME"; \
     apt-get remove --purge --auto-remove -y gnupg1 && rm -rf /var/lib/apt/lists/* \
     && dpkgArch="$(dpkg --print-architecture)" \


### PR DESCRIPTION
This makes sure all keys are exported to a keyring archive, as opposed to only the first key.

Same as in https://github.com/nginx/docker-nginx/commit/0b49b8b12fd214b633114ac16d2dfd65d45ff160