### PR TITLE
feat: Update mainline NGINX to 1.29.4

### DIFF
--- a/mainline/alpine-otel/Dockerfile
+++ b/mainline/alpine-otel/Dockerfile
@@ -3,7 +3,7 @@
 #
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
-ARG IMAGE=nginxinc/nginx-unprivileged:1.29.3-alpine
+ARG IMAGE=nginxinc/nginx-unprivileged:1.29.4-alpine
 FROM $IMAGE
 
 ENV OTEL_VERSION=0.1.2

--- a/mainline/alpine-perl/Dockerfile
+++ b/mainline/alpine-perl/Dockerfile
@@ -3,7 +3,7 @@
 #
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
-ARG IMAGE=nginxinc/nginx-unprivileged:1.29.3-alpine
+ARG IMAGE=nginxinc/nginx-unprivileged:1.29.4-alpine
 FROM $IMAGE
 
 ARG UID=101

--- a/mainline/alpine-slim/Dockerfile
+++ b/mainline/alpine-slim/Dockerfile
@@ -8,7 +8,7 @@ FROM $IMAGE
 
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
-ENV NGINX_VERSION=1.29.3
+ENV NGINX_VERSION=1.29.4
 ENV PKG_RELEASE=1
 ENV DYNPKG_RELEASE=1
 

--- a/mainline/alpine/Dockerfile
+++ b/mainline/alpine/Dockerfile
@@ -3,7 +3,7 @@
 #
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
-ARG IMAGE=nginxinc/nginx-unprivileged:1.29.3-alpine-slim
+ARG IMAGE=nginxinc/nginx-unprivileged:1.29.4-alpine-slim
 FROM $IMAGE
 
 ENV NJS_VERSION=0.9.4

--- a/mainline/debian-otel/Dockerfile
+++ b/mainline/debian-otel/Dockerfile
@@ -3,7 +3,7 @@
 #
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
-ARG IMAGE=nginxinc/nginx-unprivileged:1.29.3
+ARG IMAGE=nginxinc/nginx-unprivileged:1.29.4
 FROM $IMAGE
 
 ENV OTEL_VERSION=0.1.2

--- a/mainline/debian-perl/Dockerfile
+++ b/mainline/debian-perl/Dockerfile
@@ -3,7 +3,7 @@
 #
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
-ARG IMAGE=nginxinc/nginx-unprivileged:1.29.3
+ARG IMAGE=nginxinc/nginx-unprivileged:1.29.4
 FROM $IMAGE
 
 ARG UID=101

--- a/mainline/debian/Dockerfile
+++ b/mainline/debian/Dockerfile
@@ -8,7 +8,7 @@ FROM $IMAGE
 
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com>"
 
-ENV NGINX_VERSION=1.29.3
+ENV NGINX_VERSION=1.29.4
 ENV NJS_VERSION=0.9.4
 ENV NJS_RELEASE=1~trixie
 ENV PKG_RELEASE=1~trixie

--- a/update.sh
+++ b/update.sh
@@ -12,7 +12,7 @@ declare branches=(
 # Current nginx versions
 # Remember to update pkgosschecksum when changing this.
 declare -A nginx=(
-    [mainline]='1.29.3'
+    [mainline]='1.29.4'
     [stable]='1.28.0'
 )
 


### PR DESCRIPTION
### Proposed changes

updates the mainline nginx version to 1.29.4

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md)
- [x] I have run the [`update.sh`](/update.sh) script and ensured all entrypoint/Dockerfile template changes have been applied to the relevant image entrypoint scripts & Dockerfiles
- [x] I have tested that the NGINX Docker unprivileged image builds and runs correctly on all supported architectures on an unprivileged environment (check out the [`README`](/README.md) for more details)
- [x] I have updated any relevant documentation ([`README.md`](/README.md))
