### PR TITLE
fix: Use temp file for IPv6 conf checksum (#228)

### DIFF
--- a/entrypoint/10-listen-on-ipv6-by-default.sh
+++ b/entrypoint/10-listen-on-ipv6-by-default.sh
@@ -37,18 +37,22 @@ else
 fi
 
 entrypoint_log "$ME: info: Getting the checksum of /$DEFAULT_CONF_FILE"
+# Use a temporary file to undo the port change so checksums can be compared.
+CONFTMP=$(mktemp)
+trap 'rm -f "$CONFTMP"' EXIT SIGINT
+sed 's,listen       8080;,listen       80;,' "/$DEFAULT_CONF_FILE" > "$CONFTMP"
 
 case "$ID" in
     "debian")
         CHECKSUM=$(dpkg-query --show --showformat='${Conffiles}\n' nginx | grep $DEFAULT_CONF_FILE | cut -d' ' -f 3)
-        echo "$CHECKSUM  /$DEFAULT_CONF_FILE" | md5sum -c - >/dev/null 2>&1 || {
+        echo "$CHECKSUM  $CONFTMP" | md5sum -c - >/dev/null 2>&1 || {
             entrypoint_log "$ME: info: /$DEFAULT_CONF_FILE differs from the packaged version"
             exit 0
         }
         ;;
     "alpine")
         CHECKSUM=$(apk manifest nginx 2>/dev/null| grep $DEFAULT_CONF_FILE | cut -d' ' -f 1 | cut -d ':' -f 2)
-        echo "$CHECKSUM  /$DEFAULT_CONF_FILE" | sha1sum -c - >/dev/null 2>&1 || {
+        echo "$CHECKSUM  $CONFTMP" | sha1sum -c - >/dev/null 2>&1 || {
             entrypoint_log "$ME: info: /$DEFAULT_CONF_FILE differs from the packaged version"
             exit 0
         }


### PR DESCRIPTION
### Proposed changes

The conf file has been modified to change listen port in the Dockerfile, so to correctly compare packaged checksums we create a temporary file with the known changes reverted.

This resolves an issue where the container would never listen on IPv6 on startup.

resolves #228 #114 

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md)
- [x] I have run the [`update.sh`](/update.sh) script and ensured all entrypoint/Dockerfile template changes have been applied to the relevant image entrypoint scripts & Dockerfiles
- [x] I have tested that the NGINX Docker unprivileged image builds and runs correctly on all supported architectures on an unprivileged environment (check out the [`README`](/README.md) for more details)
- [x] I have updated any relevant documentation ([`README.md`](/README.md))
