### PR TITLE
feat: Migrate to OIDC-based authentication to AWS services

### DIFF
--- a/.github/workflows/alpine-mainline.yml
+++ b/.github/workflows/alpine-mainline.yml
@@ -52,8 +52,8 @@ jobs:
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
         with:
           aws-region: ${{ secrets.AWS_REGION }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ECR_PUBLIC_RW }}
+          role-duration-seconds: 14400
 
       - name: Login to Amazon ECR Public Gallery
         if: ${{ github.event_name != 'pull_request' }}
@@ -170,8 +170,8 @@ jobs:
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
         with:
           aws-region: ${{ secrets.AWS_REGION }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ECR_PUBLIC_RW }}
+          role-duration-seconds: 14400
 
       - name: Login to Amazon ECR Public Gallery
         if: ${{ github.event_name != 'pull_request' }}
@@ -288,8 +288,8 @@ jobs:
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
         with:
           aws-region: ${{ secrets.AWS_REGION }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ECR_PUBLIC_RW }}
+          role-duration-seconds: 14400
 
       - name: Login to Amazon ECR Public Gallery
         if: ${{ github.event_name != 'pull_request' }}
@@ -406,8 +406,8 @@ jobs:
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
         with:
           aws-region: ${{ secrets.AWS_REGION }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ECR_PUBLIC_RW }}
+          role-duration-seconds: 14400
 
       - name: Login to Amazon ECR Public Gallery
         if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/alpine-stable.yml
+++ b/.github/workflows/alpine-stable.yml
@@ -52,8 +52,8 @@ jobs:
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
         with:
           aws-region: ${{ secrets.AWS_REGION }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ECR_PUBLIC_RW }}
+          role-duration-seconds: 14400
 
       - name: Login to Amazon ECR Public Gallery
         if: ${{ github.event_name != 'pull_request' }}
@@ -162,8 +162,8 @@ jobs:
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
         with:
           aws-region: ${{ secrets.AWS_REGION }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ECR_PUBLIC_RW }}
+          role-duration-seconds: 14400
 
       - name: Login to Amazon ECR Public Gallery
         if: ${{ github.event_name != 'pull_request' }}
@@ -272,8 +272,8 @@ jobs:
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
         with:
           aws-region: ${{ secrets.AWS_REGION }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ECR_PUBLIC_RW }}
+          role-duration-seconds: 14400
 
       - name: Login to Amazon ECR Public Gallery
         if: ${{ github.event_name != 'pull_request' }}
@@ -381,8 +381,8 @@ jobs:
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
         with:
           aws-region: ${{ secrets.AWS_REGION }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ECR_PUBLIC_RW }}
+          role-duration-seconds: 14400
 
       - name: Login to Amazon ECR Public Gallery
         if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/debian-mainline.yml
+++ b/.github/workflows/debian-mainline.yml
@@ -52,8 +52,8 @@ jobs:
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
         with:
           aws-region: ${{ secrets.AWS_REGION }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ECR_PUBLIC_RW }}
+          role-duration-seconds: 14400
 
       - name: Login to Amazon ECR Public Gallery
         if: ${{ github.event_name != 'pull_request' }}
@@ -171,8 +171,8 @@ jobs:
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
         with:
           aws-region: ${{ secrets.AWS_REGION }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ECR_PUBLIC_RW }}
+          role-duration-seconds: 14400
 
       - name: Login to Amazon ECR Public Gallery
         if: ${{ github.event_name != 'pull_request' }}
@@ -290,8 +290,8 @@ jobs:
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
         with:
           aws-region: ${{ secrets.AWS_REGION }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ECR_PUBLIC_RW }}
+          role-duration-seconds: 14400
 
       - name: Login to Amazon ECR Public Gallery
         if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/debian-stable.yml
+++ b/.github/workflows/debian-stable.yml
@@ -52,8 +52,8 @@ jobs:
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
         with:
           aws-region: ${{ secrets.AWS_REGION }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ECR_PUBLIC_RW }}
+          role-duration-seconds: 14400
 
       - name: Login to Amazon ECR Public Gallery
         if: ${{ github.event_name != 'pull_request' }}
@@ -163,8 +163,8 @@ jobs:
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
         with:
           aws-region: ${{ secrets.AWS_REGION }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ECR_PUBLIC_RW }}
+          role-duration-seconds: 14400
 
       - name: Login to Amazon ECR Public Gallery
         if: ${{ github.event_name != 'pull_request' }}
@@ -274,8 +274,8 @@ jobs:
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
         with:
           aws-region: ${{ secrets.AWS_REGION }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ECR_PUBLIC_RW }}
+          role-duration-seconds: 14400
 
       - name: Login to Amazon ECR Public Gallery
         if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -20,8 +20,8 @@ jobs:
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
         with:
           aws-region: ${{ secrets.AWS_REGION }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ECR_PUBLIC_RW }}
+          role-duration-seconds: 3600
 
       - name: Delete untagged NGINX Unprivileged Docker images on the Amazon ECR Public Gallery
         run: |


### PR DESCRIPTION
### Proposed changes

This PR changes the workflows to use OIDC-based authentication to AWS services.  This allows us to drop long-lived credentials and utilize GH tokens to authenticate against AWS IDP.  The secret that holds the role name is already created for the repo.