### PR TITLE
fix: AWS OIDC login

### DIFF
--- a/.github/workflows/alpine-mainline.yml
+++ b/.github/workflows/alpine-mainline.yml
@@ -37,6 +37,8 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
+    permissions:
+      id-token: write
     steps:
       - name: Check out the codebase
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -155,6 +157,8 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
+    permissions:
+      id-token: write
     steps:
       - name: Check out the codebase
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -273,6 +277,8 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
+    permissions:
+      id-token: write
     steps:
       - name: Check out the codebase
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/alpine-stable.yml
+++ b/.github/workflows/alpine-stable.yml
@@ -37,6 +37,8 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
+    permissions:
+      id-token: write
     steps:
       - name: Check out the codebase
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -147,6 +149,8 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
+    permissions:
+      id-token: write
     steps:
       - name: Check out the codebase
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -257,6 +261,8 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
+    permissions:
+      id-token: write
     steps:
       - name: Check out the codebase
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -366,6 +372,8 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
+    permissions:
+      id-token: write
     steps:
       - name: Check out the codebase
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/debian-mainline.yml
+++ b/.github/workflows/debian-mainline.yml
@@ -37,6 +37,8 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
+    permissions:
+      id-token: write
     steps:
       - name: Check out the codebase
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -156,6 +158,8 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
+    permissions:
+      id-token: write
     steps:
       - name: Check out the codebase
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -275,6 +279,8 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
+    permissions:
+      id-token: write
     steps:
       - name: Check out the codebase
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/debian-stable.yml
+++ b/.github/workflows/debian-stable.yml
@@ -37,6 +37,8 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
+    permissions:
+      id-token: write
     steps:
       - name: Check out the codebase
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -148,6 +150,8 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
+    permissions:
+      id-token: write
     steps:
       - name: Check out the codebase
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -259,6 +263,8 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
+    permissions:
+      id-token: write
     steps:
       - name: Check out the codebase
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
### Proposed changes

#379 did not include the GitHub Actions workflow permission for `id_token`.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md)
- [x] I have run the [`update.sh`](/update.sh) script and ensured all entrypoint/Dockerfile template changes have been applied to the relevant image entrypoint scripts & Dockerfiles
- [x] I have tested that the NGINX Docker unprivileged image builds and runs correctly on all supported architectures on an unprivileged environment (check out the [`README`](/README.md) for more details)
- [x] I have updated any relevant documentation ([`README.md`](/README.md))
