### PR TITLE
fix: Add GH Actions workflow permission to write packages to GHCR

### DIFF
--- a/.github/workflows/alpine-mainline.yml
+++ b/.github/workflows/alpine-mainline.yml
@@ -39,6 +39,7 @@ jobs:
       fail-fast: false
     permissions:
       id-token: write
+      packages: write
     steps:
       - name: Check out the codebase
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -159,6 +160,7 @@ jobs:
       fail-fast: false
     permissions:
       id-token: write
+      packages: write
     steps:
       - name: Check out the codebase
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -279,6 +281,7 @@ jobs:
       fail-fast: false
     permissions:
       id-token: write
+      packages: write
     steps:
       - name: Check out the codebase
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -397,6 +400,9 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
+    permissions:
+      id-token: write
+      packages: write
     steps:
       - name: Check out the codebase
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/alpine-stable.yml
+++ b/.github/workflows/alpine-stable.yml
@@ -39,6 +39,7 @@ jobs:
       fail-fast: false
     permissions:
       id-token: write
+      packages: write
     steps:
       - name: Check out the codebase
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -151,6 +152,7 @@ jobs:
       fail-fast: false
     permissions:
       id-token: write
+      packages: write
     steps:
       - name: Check out the codebase
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -263,6 +265,7 @@ jobs:
       fail-fast: false
     permissions:
       id-token: write
+      packages: write
     steps:
       - name: Check out the codebase
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -374,6 +377,7 @@ jobs:
       fail-fast: false
     permissions:
       id-token: write
+      packages: write
     steps:
       - name: Check out the codebase
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/debian-mainline.yml
+++ b/.github/workflows/debian-mainline.yml
@@ -39,6 +39,7 @@ jobs:
       fail-fast: false
     permissions:
       id-token: write
+      packages: write
     steps:
       - name: Check out the codebase
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -160,6 +161,7 @@ jobs:
       fail-fast: false
     permissions:
       id-token: write
+      packages: write
     steps:
       - name: Check out the codebase
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -281,6 +283,7 @@ jobs:
       fail-fast: false
     permissions:
       id-token: write
+      packages: write
     steps:
       - name: Check out the codebase
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/debian-stable.yml
+++ b/.github/workflows/debian-stable.yml
@@ -39,6 +39,7 @@ jobs:
       fail-fast: false
     permissions:
       id-token: write
+      packages: write
     steps:
       - name: Check out the codebase
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -152,6 +153,7 @@ jobs:
       fail-fast: false
     permissions:
       id-token: write
+      packages: write
     steps:
       - name: Check out the codebase
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -265,6 +267,7 @@ jobs:
       fail-fast: false
     permissions:
       id-token: write
+      packages: write
     steps:
       - name: Check out the codebase
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
### Proposed changes

https://github.com/nginx/docker-nginx-unprivileged/pull/392 introduced a different bug in the GH Actions workflow in that all permissions now need to be explicitly included. This PR should allow images to get pushed to GHCR.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md)
- [x] I have run the [`update.sh`](/update.sh) script and ensured all entrypoint/Dockerfile template changes have been applied to the relevant image entrypoint scripts & Dockerfiles
- [x] I have tested that the NGINX Docker unprivileged image builds and runs correctly on all supported architectures on an unprivileged environment (check out the [`README`](/README.md) for more details)
- [x] I have updated any relevant documentation ([`README.md`](/README.md))
