### PR TITLE
fix: Add missing permissions to GH Actions image cleanup workflow

### DIFF
--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
+    permissions:
+      id-token: write
+      packages: write
     steps:
       - name: Check out the codebase
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
### Proposed changes

The GH Actions image-cleanup workflow was missing the correct permissions per https://github.com/nginx/docker-nginx-unprivileged/pull/392 and https://github.com/nginx/docker-nginx-unprivileged/pull/395.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md)
- [x] I have run the [`update.sh`](/update.sh) script and ensured all entrypoint/Dockerfile template changes have been applied to the relevant image entrypoint scripts & Dockerfiles
- [x] I have tested that the NGINX Docker unprivileged image builds and runs correctly on all supported architectures on an unprivileged environment (check out the [`README`](/README.md) for more details)
- [x] I have updated any relevant documentation ([`README.md`](/README.md))
