### PR TITLE
Fix: Add apk upgrade to fix CVE-2026-25646 in libpng

### DIFF
--- a/mainline/alpine/Dockerfile
+++ b/mainline/alpine/Dockerfile
@@ -14,6 +14,8 @@ ARG GID=101
 
 USER root
 
+RUN apk upgrade --no-cache
+
 RUN set -x \
     && apkArch="$(cat /etc/apk/arch)" \
     && nginxPackages=" \


### PR DESCRIPTION
This PR fixes the Trivy HIGH vulnerability found in `nginxinc/nginx-unprivileged:1.29-alpine`.

**Image reference from Helm chart:**
repository: nginxinc/nginx-unprivileged
tag: "1.29-alpine"

### 1. Original Vulnerability Scan
Command:
`trivy image --severity HIGH,CRITICAL nginxinc/nginx-unprivileged:1.29-alpine`

Output:
```
2026-02-25T14:15:40Z	INFO	[vuln] Vulnerability scanning is enabled
2026-02-25T14:15:40Z	INFO	[secret] Secret scanning is enabled
2026-02-25T14:15:40Z	INFO	[secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2026-02-25T14:15:40Z	INFO	[secret] Please see https://trivy.dev/docs/v0.69/guide/scanner/secret#recommendation for faster secret detection
2026-02-25T14:15:41Z	INFO	Detected OS	family="alpine" version="3.23.3"
2026-02-25T14:15:41Z	INFO	[alpine] Detecting vulnerabilities...	os_version="3.23" repository="3.23" pkg_num=71
2026-02-25T14:15:41Z	INFO	Number of language-specific files	num=0

Report Summary

┌─────────────────────────────────────────────────────────┬────────┬─────────────────┬─────────┐
│                         Target                          │  Type  │ Vulnerabilities │ Secrets │
├─────────────────────────────────────────────────────────┼────────┼─────────────────┼─────────┤
│ nginxinc/nginx-unprivileged:1.29-alpine (alpine 3.23.3) │ alpine │        1        │    -    │
└─────────────────────────────────────────────────────────┴────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)


nginxinc/nginx-unprivileged:1.29-alpine (alpine 3.23.3)
=======================================================
Total: 1 (HIGH: 1, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬──────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                    Title                     │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼──────────────────────────────────────────────┤
│ libpng  │ CVE-2026-25646 │ HIGH     │ fixed  │ 1.6.54-r0         │ 1.6.55-r0     │ libpng: LIBPNG has a heap buffer overflow in │
│         │                │          │        │                   │               │ png_set_quantize                             │
│         │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2026-25646   │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴──────────────────────────────────────────────┘
```

### 2. The Fix
Added `RUN apk upgrade --no-cache` to the Dockerfile after switching to USER root. This upgrades all Alpine packages, including `libpng` from 1.6.54-r0 to 1.6.55-r0, which fixes CVE-2026-25646.

Command:
`docker build -t nginx-unprivileged-fixed .`

### 3. Verification Scan
Command:
`trivy image --severity HIGH,CRITICAL nginx-unprivileged-fixed`

Output:
```
2026-02-25T14:15:41Z	INFO	[vuln] Vulnerability scanning is enabled
2026-02-25T14:15:41Z	INFO	[secret] Secret scanning is enabled
2026-02-25T14:15:41Z	INFO	[secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2026-02-25T14:15:41Z	INFO	[secret] Please see https://trivy.dev/docs/v0.69/guide/scanner/secret#recommendation for faster secret detection
2026-02-25T14:15:41Z	INFO	Detected OS	family="alpine" version="3.23.3"
2026-02-25T14:15:41Z	INFO	[alpine] Detecting vulnerabilities...	os_version="3.23" repository="3.23" pkg_num=71
2026-02-25T14:15:41Z	INFO	Number of language-specific files	num=0

Report Summary

┌──────────────────────────────────────────┬────────┬─────────────────┬─────────┐
│                  Target                  │  Type  │ Vulnerabilities │ Secrets │
├──────────────────────────────────────────┼────────┼─────────────────┼─────────┤
│ nginx-unprivileged-fixed (alpine 3.23.3) │ alpine │        0        │    -    │
└──────────────────────────────────────────┴────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)

```
